### PR TITLE
Split out manual CookieConsent parsing into it's own function

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ if (consented(Consent.statistics)) {
   // Do something..
 }
 
+// Manually parse the CookieConsent cookie
+parseCookieConsent(Cookies.get('CookieConsent'), Consent.statistics)
+
 // Run function after consent
 deferRun(() => {
   doSomething()

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ if (consented(Consent.statistics)) {
   // Do something..
 }
 
-// Manually parse the CookieConsent cookie
-parseCookieConsent(Cookies.get('CookieConsent'), Consent.statistics)
+// Manually parse and check the consent type in the CookieConsent cookie
+checkCookieConsent(Cookies.get('CookieConsent'), Consent.statistics)
 
 // Run function after consent
 deferRun(() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envato/cookie-consent",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Some helper functions to deal with cookie-consent",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import * as mockCookie from 'js-cookie'
 
-import { Consent, consented, deferRun, parseCookieConsent } from './index'
+import { Consent, consented, deferRun, checkCookieConsent } from './index'
 
 const castedMockCookie = mockCookie as any
 
@@ -34,37 +34,37 @@ describe('consented()', () => {
 })
 
 describe('parseCookieConsent()', () => {
-  let CookieConsent: string | undefined
+  let CookieString: string | undefined
   describe('when CookieConsent is undefined', () => {
     it('returns false', () => {
-      expect(parseCookieConsent(CookieConsent, Consent.statistics)).toBe(false)
+      expect(checkCookieConsent(CookieString, Consent.statistics)).toBe(false)
     })
   })
   describe('when CookieConsent is found', () => {
     beforeEach(() => {
-      CookieConsent = undefined
+      CookieString = undefined
     })
 
     it('returns true for user outside of targeted area', () => {
-      CookieConsent = '-1'
-      expect(parseCookieConsent(CookieConsent, Consent.statistics)).toBe(true)
+      CookieString = '-1'
+      expect(checkCookieConsent(CookieString, Consent.statistics)).toBe(true)
     })
 
     it('returns false if issue parsing cookie', () => {
-      CookieConsent = '{bad: "json}'
-      expect(parseCookieConsent(CookieConsent, Consent.statistics)).toBe(false)
+      CookieString = '{bad: "json}'
+      expect(checkCookieConsent(CookieString, Consent.statistics)).toBe(false)
     })
 
     it('returns true if user has consented', () => {
-      CookieConsent =
+      CookieString =
         "{stamp:'X',necessary:true,preferences:false,statistics:true,marketing:true,ver:1}"
-      expect(parseCookieConsent(CookieConsent, Consent.statistics)).toBe(true)
+      expect(checkCookieConsent(CookieString, Consent.statistics)).toBe(true)
     })
 
     it('returns false if user has not consented', () => {
-      CookieConsent =
+      CookieString =
         "{stamp:'X',necessary:true,preferences:false,statistics:false,marketing:true,ver:1}"
-      expect(parseCookieConsent(CookieConsent, Consent.statistics)).toBe(false)
+      expect(checkCookieConsent(CookieString, Consent.statistics)).toBe(false)
     })
   })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import * as mockCookie from 'js-cookie'
 
-import { Consent, consented, deferRun } from './index'
+import { Consent, consented, deferRun, parseCookieConsent } from './index'
 
 const castedMockCookie = mockCookie as any
 
@@ -29,6 +29,42 @@ describe('consented()', () => {
     })
     it('return false for disallowed category', () => {
       expect(consented(Consent.marketing)).toBe(false)
+    })
+  })
+})
+
+describe('parseCookieConsent()', () => {
+  let CookieConsent: string | undefined
+  describe('when CookieConsent is undefined', () => {
+    it('returns false', () => {
+      expect(parseCookieConsent(CookieConsent, Consent.statistics)).toBe(false)
+    })
+  })
+  describe('when CookieConsent is found', () => {
+    beforeEach(() => {
+      CookieConsent = undefined
+    })
+
+    it('returns true for user outside of targeted area', () => {
+      CookieConsent = '-1'
+      expect(parseCookieConsent(CookieConsent, Consent.statistics)).toBe(true)
+    })
+
+    it('returns false if issue parsing cookie', () => {
+      CookieConsent = '{bad: "json}'
+      expect(parseCookieConsent(CookieConsent, Consent.statistics)).toBe(false)
+    })
+
+    it('returns true if user has consented', () => {
+      CookieConsent =
+        "{stamp:'X',necessary:true,preferences:false,statistics:true,marketing:true,ver:1}"
+      expect(parseCookieConsent(CookieConsent, Consent.statistics)).toBe(true)
+    })
+
+    it('returns false if user has not consented', () => {
+      CookieConsent =
+        "{stamp:'X',necessary:true,preferences:false,statistics:false,marketing:true,ver:1}"
+      expect(parseCookieConsent(CookieConsent, Consent.statistics)).toBe(false)
     })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,21 +43,10 @@ if (typeof window !== 'undefined') {
   )
 }
 
-export const consented = (consent: Consent) => {
-  if (!(typeof window !== 'undefined')) {
-    return false
-  }
-
-  // when cookiebot is avaiable use it
-  if (
-    !!(window && (window as any).Cookiebot && (window as any).Cookiebot.consent)
-  ) {
-    return !!(window as any).Cookiebot.consent[consent]
-  }
-
-  // manually parse cookie if Cookiebot is not avaiable
-  const CookieConsent = Cookies.get('CookieConsent')
-
+export const parseCookieConsent = (
+  CookieConsent: string | undefined,
+  consent: Consent
+) => {
   if (!CookieConsent) {
     return false
   }
@@ -77,4 +66,21 @@ export const consented = (consent: Consent) => {
   } catch (e) {
     return false
   }
+}
+
+export const consented = (consent: Consent) => {
+  if (!(typeof window !== 'undefined')) {
+    return false
+  }
+
+  // when cookiebot is avaiable use it
+  if (
+    !!(window && (window as any).Cookiebot && (window as any).Cookiebot.consent)
+  ) {
+    return !!(window as any).Cookiebot.consent[consent]
+  }
+
+  // manually parse cookie if Cookiebot is not avaiable
+  const CookieConsent = Cookies.get('CookieConsent')
+  return parseCookieConsent(CookieConsent, consent)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,22 +43,22 @@ if (typeof window !== 'undefined') {
   )
 }
 
-export const parseCookieConsent = (
-  CookieConsent: string | undefined,
+export const checkCookieConsent = (
+  CookieString: string | undefined,
   consent: Consent
 ) => {
-  if (!CookieConsent) {
+  if (!CookieString) {
     return false
   }
 
   // For user outside of targeted area
-  if (CookieConsent === '-1') {
+  if (CookieString === '-1') {
     return true
   }
 
   try {
     const parsedCookieConsent = JSON.parse(
-      CookieConsent.replace(/%2c/g, ',')
+      CookieString.replace(/%2c/g, ',')
         .replace(/'/g, '"')
         .replace(/([{\[,])\s*([a-zA-Z0-9_]+?):/g, '$1"$2":')
     )
@@ -82,5 +82,5 @@ export const consented = (consent: Consent) => {
 
   // manually parse cookie if Cookiebot is not avaiable
   const CookieConsent = Cookies.get('CookieConsent')
-  return parseCookieConsent(CookieConsent, consent)
+  return checkCookieConsent(CookieConsent, consent)
 }


### PR DESCRIPTION
## Description
This splits out the manual `CookieConsent` cookie parsing from the `consented` function into its own exported, `parseCookieConsent` function.

## Reasoning
Elements has a server redirect in place for handling some internationalisation redirects that are set in cookies. If a user has the `CookieConsent` cookie we want to be able to manually try and parse that upfront.

## What's changed
- Split out the manual parsing portion of the `consented` function to its own `parseCookieConsent`
- Added tests for `parseCookieConsent` function
  - Tests largely repeat what's tested in `deferRun` but since we're exporting separately I'd rather these be tested separately too.
- Updated version to `1.1.0`