### PR TITLE
Guard against there being no window object 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envato/cookie-consent",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Some helper functions to deal with cookie-consent",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,9 +27,12 @@ const execute = () => {
 }
 
 export const deferRun = (job: () => any, consent: Consent) => {
-  queue.push({ job, consent })
-  if ((window as any).Cookiebot && (window as any).Cookiebot.hasResponse) {
-    execute()
+  if (typeof window !== 'undefined') {
+    queue.push({ job, consent })
+
+    if ((window as any).Cookiebot && (window as any).Cookiebot.hasResponse) {
+      execute()
+    }
   }
 }
 


### PR DESCRIPTION
## Context

The `deferRun` function doesn't currently guard against there being no window object in the instance we're server rendering

## Changes
- Added a guard against the `window` object into the `deferRun` function