### PR TITLE
Make queue function as queue instead of stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envato/cookie-consent",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Some helper functions to deal with cookie-consent",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -89,6 +89,16 @@ describe('deferRun()', () => {
       window.dispatchEvent(new CustomEvent('CookiebotOnAccept'))
       expect(intercomMock).toBeCalled()
     })
+
+    it('runs them in the right order', () => {
+      jest.clearAllMocks()
+      deferRun(() => intercomMock(1), Consent.statistics)
+      deferRun(() => intercomMock(2), Consent.statistics)
+      ;(window as any).Cookiebot.consent.statistics = true
+      window.dispatchEvent(new CustomEvent('CookiebotOnAccept'))
+      expect(intercomMock.mock.calls[0][0]).toEqual(1)
+      expect(intercomMock.mock.calls[1][0]).toEqual(2)
+    })
   })
 
   describe('cookiebot has response and consent', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export enum Consent {
 
 const execute = () => {
   while (queue.length) {
-    const cookiebotJob = queue.pop()
+    const cookiebotJob = queue.shift()
     if (cookiebotJob) {
       const { job, consent } = cookiebotJob
       // what to do if Cookiebot fail to load or blocked?


### PR DESCRIPTION
Until now the queue of deferred jobs functioned as a stack - new elements are added to the end of the array, and elements are also removed from the end of the array. We are using the deferred jobs to queue GA events, which we need to send off in the order that they happen.

This change makes the queue function as a queue - new elements are added to the end of the array, and elements are removed from the start of the array.

We haven't added a test for the ordering of the deferred jobs, as there wasn't a test for this functionality previously, but we are happy to add one!

CC: @doylem @PakkuDon 