### PR TITLE
Implement user has opted out of cookies for category function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+node_js:
+  - '10'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@envato/cookie-consent",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envato/cookie-consent",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Some helper functions to deal with cookie-consent",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "jest",
+    "test": "jest ./src/*.test.ts",
     "prepublishOnly": "npm test && npm run build"
   },
   "files": [

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -185,7 +185,7 @@ describe('deferRun()', () => {
   })
 })
 
-describe.only('userHasOptedOutOfCookiesForCategory()', () => {
+describe('userHasOptedOutOfCookiesForCategory()', () => {
   beforeEach(() => {
     castedMockCookie.get.mockReset()
     castedMockCookie.set.mockReset()
@@ -236,7 +236,7 @@ describe.only('userHasOptedOutOfCookiesForCategory()', () => {
     })
   })
 
-  describe.only('with cookiebot not loaded', () => {
+  describe('with cookiebot not loaded', () => {
     it('return false when no cookie', () => {
       castedMockCookie.get.mockImplementation(() => undefined)
       expect(userHasOptedOutOfCookiesForCategory(Consent.statistics)).toBe(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,12 @@
-import * as mockCookie from 'js-cookie'
+import mockCookie from 'js-cookie'
 
-import { Consent, consented, deferRun, checkCookieConsent } from './index'
+import {
+  Consent,
+  consented,
+  deferRun,
+  checkCookieConsent,
+  userHasOptedOutOfCookiesForCategory
+} from './index'
 
 const castedMockCookie = mockCookie as any
 
@@ -175,6 +181,99 @@ describe('deferRun()', () => {
           "{stamp:'xJB03YkuI2LicNIfQSnHClMF+YsNEHjsCyQgEKSFPW5UbP8sXHXM1g==',necessary:true,preferences:true,statistics:false,marketing:true,ver:1}"
       )
       expect(consented(Consent.statistics)).toBe(false)
+    })
+  })
+})
+
+describe.only('userHasOptedOutOfCookiesForCategory()', () => {
+  beforeEach(() => {
+    castedMockCookie.get.mockReset()
+    castedMockCookie.set.mockReset()
+    ;(window as any).Cookiebot = null
+  })
+
+  describe('default', () => {
+    it('to false', () => {
+      expect(userHasOptedOutOfCookiesForCategory(Consent.statistics)).toBe(
+        false
+      )
+    })
+  })
+
+  describe('with cookiebot loaded but no response', () => {
+    beforeAll(() => {
+      ;(window as any).Cookiebot = {
+        consent: {
+          statistics: false,
+          marketing: false
+        },
+        hasResponse: false
+      }
+    })
+    it('return false', () => {
+      expect(userHasOptedOutOfCookiesForCategory(Consent.statistics)).toBe(
+        false
+      )
+    })
+  })
+
+  describe('with cookiebot loaded and with response', () => {
+    beforeEach(() => {
+      ;(window as any).Cookiebot = {
+        consent: {
+          statistics: false,
+          marketing: false
+        },
+        hasResponse: true
+      }
+    })
+    describe('return false', () => {
+      it('return false', () => {
+        expect(userHasOptedOutOfCookiesForCategory(Consent.statistics)).toBe(
+          true
+        )
+      })
+    })
+  })
+
+  describe.only('with cookiebot not loaded', () => {
+    it('return false when no cookie', () => {
+      castedMockCookie.get.mockImplementation(() => undefined)
+      expect(userHasOptedOutOfCookiesForCategory(Consent.statistics)).toBe(
+        false
+      )
+    })
+
+    it('return false when outside or region', () => {
+      castedMockCookie.get.mockImplementation(() => '-1')
+      expect(userHasOptedOutOfCookiesForCategory(Consent.statistics)).toBe(
+        false
+      )
+    })
+
+    it('return false if having issue parse cookie', () => {
+      castedMockCookie.get.mockImplementation(() => '{bad: "json}')
+      expect(userHasOptedOutOfCookiesForCategory(Consent.statistics)).toBe(
+        false
+      )
+    })
+
+    it('return true when user has consent set to true', () => {
+      castedMockCookie.get.mockImplementation(
+        () =>
+          "{stamp:'xJB03YkuI2LicNIfQSnHClMF+YsNEHjsCyQgEKSFPW5UbP8sXHXM1g==',necessary:true,preferences:true,statistics:true,marketing:true,ver:1}"
+      )
+      expect(userHasOptedOutOfCookiesForCategory(Consent.statistics)).toBe(
+        false
+      )
+    })
+
+    it('return false when user has consent set to false', () => {
+      castedMockCookie.get.mockImplementation(
+        () =>
+          "{stamp:'xJB03YkuI2LicNIfQSnHClMF+YsNEHjsCyQgEKSFPW5UbP8sXHXM1g==',necessary:true,preferences:true,statistics:false,marketing:true,ver:1}"
+      )
+      expect(userHasOptedOutOfCookiesForCategory(Consent.statistics)).toBe(true)
     })
   })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -227,12 +227,8 @@ describe('userHasOptedOutOfCookiesForCategory()', () => {
         hasResponse: true
       }
     })
-    describe('return false', () => {
-      it('return false', () => {
-        expect(userHasOptedOutOfCookiesForCategory(Consent.statistics)).toBe(
-          true
-        )
-      })
+    it('return false', () => {
+      expect(userHasOptedOutOfCookiesForCategory(Consent.statistics)).toBe(true)
     })
   })
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -217,7 +217,7 @@ describe('userHasOptedOutOfCookiesForCategory()', () => {
     })
   })
 
-  describe('with cookiebot loaded and with response', () => {
+  describe('with cookiebot loaded and with response to false', () => {
     beforeEach(() => {
       ;(window as any).Cookiebot = {
         consent: {
@@ -227,8 +227,25 @@ describe('userHasOptedOutOfCookiesForCategory()', () => {
         hasResponse: true
       }
     })
-    it('return false', () => {
+    it('return true', () => {
       expect(userHasOptedOutOfCookiesForCategory(Consent.statistics)).toBe(true)
+    })
+  })
+
+  describe('with cookiebot loaded and with response to true', () => {
+    beforeEach(() => {
+      ;(window as any).Cookiebot = {
+        consent: {
+          statistics: true,
+          marketing: false
+        },
+        hasResponse: true
+      }
+    })
+    it('return false', () => {
+      expect(userHasOptedOutOfCookiesForCategory(Consent.statistics)).toBe(
+        false
+      )
     })
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,3 +87,55 @@ export const consented = (consent: Consent) => {
   const CookieConsent = Cookies.get('CookieConsent')
   return checkCookieConsent(CookieConsent, consent)
 }
+
+export const userHasOptedOutOfCookiesForCategory = (consent: Consent) => {
+  if (!(typeof window !== 'undefined')) {
+    return false
+  }
+
+  // when cookiebot is avaiable and user has no response
+  if (
+    !!(
+      window &&
+      (window as any).Cookiebot &&
+      (window as any).Cookiebot.consent
+    ) &&
+    !(window as any).Cookiebot.hasResponse
+  ) {
+    return false
+  }
+
+  // when cookiebot is avaiable and use has response and use it
+  if (
+    !!(
+      window &&
+      (window as any).Cookiebot &&
+      (window as any).Cookiebot.consent
+    ) &&
+    (window as any).Cookiebot.hasResponse
+  ) {
+    return !(window as any).Cookiebot.consent[consent]
+  }
+
+  // manually parse cookie if Cookiebot is not avaiable
+  const CookieConsent = Cookies.get('CookieConsent')
+  if (!CookieConsent) {
+    return false
+  }
+
+  // For user outside of targeted area
+  if (CookieConsent === '-1') {
+    return false
+  }
+
+  try {
+    const parsedCookieConsent = JSON.parse(
+      CookieConsent.replace(/%2c/g, ',')
+        .replace(/'/g, '"')
+        .replace(/([{\[,])\s*([a-zA-Z0-9_]+?):/g, '$1"$2":')
+    )
+    return parsedCookieConsent && !parsedCookieConsent[consent]
+  } catch (e) {
+    return false
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,28 +93,15 @@ export const userHasOptedOutOfCookiesForCategory = (consent: Consent) => {
     return false
   }
 
-  // when cookiebot is avaiable and user has no response
+  // when cookiebot is avaiable
   if (
-    !!(
-      window &&
-      (window as any).Cookiebot &&
-      (window as any).Cookiebot.consent
-    ) &&
-    !(window as any).Cookiebot.hasResponse
+    !!(window && (window as any).Cookiebot && (window as any).Cookiebot.consent)
   ) {
-    return false
-  }
-
-  // when cookiebot is avaiable and use has response and use it
-  if (
-    !!(
-      window &&
-      (window as any).Cookiebot &&
-      (window as any).Cookiebot.consent
-    ) &&
-    (window as any).Cookiebot.hasResponse
-  ) {
-    return !(window as any).Cookiebot.consent[consent]
+    if ((window as any).Cookiebot.hasResponse) {
+      return !(window as any).Cookiebot.consent[consent]
+    } else {
+      return false
+    }
   }
 
   // manually parse cookie if Cookiebot is not avaiable


### PR DESCRIPTION
### Context
Based on the discussion in https://docs.google.com/document/d/1rV5klTPpvwO9qaEA__KH69z6bJ1lDO6HvvRFwnsV92M/edit

We want to have a shared `userHasOptedOutOfCookiesForCategory` function, so that for project that use explicit consent

* load GA by default
* if user have consent, use consent value

Please check the test to confirm the behaviour is exactly what we want.

```
  userHasOptedOutOfCookiesForCategory()
    default
      ✓ to false
    with cookiebot loaded but no response
      ✓ return false
    with cookiebot loaded and with response to false
      ✓ return true
    with cookiebot loaded and with response to true
      ✓ return false
    with cookiebot not loaded
      ✓ return false when no cookie (1ms)
      ✓ return false when outside or region
      ✓ return false if having issue parse cookie
      ✓ return true when user has consent set to true (1ms)
      ✓ return false when user has consent set to false
```

cc @bensmithett @anthb @Shervanator @AeroCross @gbakernet @pawelgalazka 