### PR TITLE
Add Selector To Remove Padding On Cookiebot Paragraph Tags

### DIFF
--- a/cookiebot.css
+++ b/cookiebot.css
@@ -4,6 +4,10 @@
   padding-top: 14px !important;
 }
 
+#CybotCookiebotDialog p {
+  padding: 0;
+}
+
 #CybotCookiebotDialogDetailBody,
 #CybotCookiebotDialogBody {
   max-width: 1152px !important;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@envato/cookie-consent",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envato/cookie-consent",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Some helper functions to deal with cookie-consent",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Add a selector that will remove top and bottom padding from paragraph  
elements within the Cookiebot banner.

This ensures that no additional padding from global css affects the  
spacing above and below each paragraph.

This is the result of PR envato/marketplace#26609