### PR TITLE
Prevent old build files from being packed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envato/cookie-consent",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Some helper functions to deal with cookie-consent",
   "main": "dist/index.js",
   "engines": {
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "tsc",
     "test": "jest ./src/*.test.ts",
-    "prepublishOnly": "npm test && npm run build"
+    "clean": "rm -rf ./dist",
+    "prepublishOnly": "npm test && npm run clean && npm run build"
   },
   "files": [
     "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,6 @@
     "noFallthroughCasesInSwitch": true,
     "strict": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
### Background Context
We noticed that the package was being built with old files that should have been removed.

### What’s this PR do?
* Adds a cleanup command that will run automatically during the build process, to get rid of old files
* Prevent test files from being included in the build
* Bump version to `2.0.1`