### PR TITLE
Automate publishing to registries with github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Publish package to registries
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-github-registry:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@envato'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release-npm-registry:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@envato'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -51,18 +51,12 @@ If using a version >= 2.0.0, **you need to load the JS snippet on your applicati
 
 The file `clsFixSnippet.ts` contains the snippet. It's being exported as a string. When including the code in your app, make sure it runs _before_ the main cookiebot code.
 
-## Changelog
-
-See [Releases](https://github.com/envato/cookie-consent/releases)
-
 ## Publishing
-
-> Do not manually publish, unless you are publishing to both github and npm registries
 
 Publishing is automated via GitHub Actions. Trigger with the following steps:
 
-1. Ensure the latest version is tagged in ` main`. eg. `git tag -m v1.1.0 && git push origin v1.1.0`
-1. Ensure the latest version is committed in the `package.json`. `"version": "1.1.0"`
+1. Ensure the latest version is tagged in `main`. eg. `git tag -a v1.1.1 -m "1.1.1" && git push origin v1.1.1`
+1. Ensure the latest version is committed in the `package.json`. `"version": "1.1.1"`
 1. Create a release via the [Github Releases](https://github.com/envato/cookie-consent/releases)
 1. Verify the build in [Github Actions](https://github.com/envato/cookie-consent/actions)
 1. Verify the package published to [Github Packages](https://github.com/envato/cookie-consent/pkgs/npm/cookie-consent)

--- a/README.md
+++ b/README.md
@@ -51,11 +51,19 @@ If using a version >= 2.0.0, **you need to load the JS snippet on your applicati
 
 The file `clsFixSnippet.ts` contains the snippet. It's being exported as a string. When including the code in your app, make sure it runs _before_ the main cookiebot code.
 
-### To publish
+## Changelog
 
-Run
+See [Releases](https://github.com/envato/cookie-consent/releases)
 
-```sh
-npm version (patch/minor/major)
-npm publish
-```
+## Publishing
+
+> Do not manually publish, unless you are publishing to both github and npm registries
+
+Publishing is automated via GitHub Actions. Trigger with the following steps:
+
+1. Ensure the latest version is tagged in ` main`. eg. `git tag -m v1.1.0 && git push origin v1.1.0`
+1. Ensure the latest version is committed in the `package.json`. `"version": "1.1.0"`
+1. Create a release via the [Github Releases](https://github.com/envato/cookie-consent/releases)
+1. Verify the build in [Github Actions](https://github.com/envato/cookie-consent/actions)
+1. Verify the package published to [Github Packages](https://github.com/envato/cookie-consent/pkgs/npm/cookie-consent)
+1. Verify the package published to [NPM](https://www.npmjs.com/package/@envato/cookie-consent?activeTab=versions)


### PR DESCRIPTION
This PR automates the publishing of the of this package to relevant registries. It follows the [offical guide](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-github-packages)

Secrets are in place.