### PR TITLE
Dependabot: check for dependency updates in `package-lock.json`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - directory: /
+    package-ecosystem: npm
+    schedule:
+      interval: monthly
+    versioning-strategy: lockfile-only
+    allow:
+      - dependency-type: all
+    groups:
+      javascript:
+        patterns:
+          - '*'
+    commit-message:
+      prefix: Dependabot


### PR DESCRIPTION
Let's keep the development dependencies current and free of security vulnerabilities.