### PR TITLE
Change version number to a valid SemVer number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envato/cookie-consent",
-  "version": "3.0.0.pre1",
+  "version": "3.0.0-pre1",
   "description": "Some helper functions to deal with cookie-consent",
   "main": "dist/index.js",
   "engines": {


### PR DESCRIPTION
Publishing this version to our package repositories is failing because pre-release version numbers should be hyphenated according SemVer.