### PR TITLE
Add styles to remove branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2024-06-28
+
+- Hide Cookiebot CMP branding
+
 ## [3.0.1] - 2024-05-31
 
 - Remove custom CSS branding

--- a/cookiebot.css
+++ b/cookiebot.css
@@ -1,9 +1,15 @@
-/* Layout */
-#CybotCookiebotDialogDetailFooter {
-  display: none;
+/* Cookiebot CMP branding */
+a#CybotCookiebotDialogPoweredbyCybot,
+div#CybotCookiebotDialogPoweredByText {
+  display: none !important;
 }
 
-/* Text content */
+/* Layout */
+#CybotCookiebotDialogDetailFooter {
+  display: none !important;
+}
+
+/* Cookie detail list */
 .CybotCookiebotDialogDetailBodyContentCookieTypeTableContainer {
   display: none !important;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@envato/cookie-consent",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Some helper functions to deal with cookie-consent",
   "main": "dist/index.js",
   "engines": {


### PR DESCRIPTION
Hiding cookiebot branding as per https://support.cookiebot.com/hc/en-us/articles/4403482346514-Remove-Cookiebot-CMP-branding-from-Swift-banner